### PR TITLE
docs: create multiple pathways to find ARG and FROM info

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -178,7 +178,8 @@ directives](#parser-directives), [comments](#format), and globally scoped
 [ARGs](#arg). The `FROM` instruction specifies the [*Parent
 Image*](https://docs.docker.com/glossary/#parent_image) from which you are
 building. `FROM` may only be preceded by one or more `ARG` instructions, which
-declare arguments that are used in `FROM` lines in the `Dockerfile`.
+declare arguments that are used in `FROM` lines in the `Dockerfile` (see
+[Understand how ARG and FROM interact](#understand-how-arg-and-from-interact)).
 
 Docker treats lines that *begin* with `#` as a comment, unless the line is
 a valid [parser directive](#parser-directives). A `#` marker anywhere
@@ -1821,6 +1822,9 @@ ARG user1
 ARG buildno
 # ...
 ```
+
+`ARG` is the only instruction that may precede `FROM` in the `Dockerfile`. See 
+[Understand how ARG and FROM interact](#understand-how-arg-and-from-interact).
 
 > **Warning:**
 >


### PR DESCRIPTION
**- What I did**
> help the reader learn of important options and side effects when reading the `ARG` or **Format** sections.
>
> looking up `ARG` in the reference misses all mention of several important facts:
> - `ARG` values are reset with each `FROM`
> - reset `ARG`s can be brought back into scope with an empty declaration
> - `ARG`s may be used in `FROM` statements
>
> these facts are well documented under `FROM` ([see _Understand how ARG and FROM interact_](https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact)), so this change tries to help the reader find that documentation when starting at `ARG` or **Format**.

**- How I did it**
> added notes to the `ARG` and **Format** sections

**- How to verify it**
> - read `/reference/builder/#arg`
> - read `reference/builder/#format`

**- Description for the changelog**
> docs: create multiple pathways to find ARG and FROM info

**- A picture of a cute animal (not mandatory but encouraged)**
> # ʕ´•ᴥ•`ʔ

